### PR TITLE
Adding capability to disable self.sinon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ This will automatically wire-up the sandbox `sinon.sandbox.create` and `sandbox.
 
 ### Options
 
-`errorOnGlobalSinonAccess` - string
+`errorOnGlobalSinonAccess` (optional) - bool
 
-Disables the use of the global `sinon` object. This ensures the use of a sandboxed version of `sinon` when in tests. 
+When set to `true`, it disables the use of the global `sinon` object. This ensures the use of a sandboxed version of `sinon` when in tests. 
 
 ### Accessing Sinon from Within Tests
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,16 @@ import setupSinonSandbox from 'ember-sinon-sandbox/test-support';
 
 ...
 
-setupSinonSandbox();
+setupSinonSandbox(options);
 ```
 
 This will automatically wire-up the sandbox `sinon.sandbox.create` and `sandbox.restore` methods to QUnit `testStart` and `testDone` respectively.
+
+### Options
+
+`errorOnGlobalSinonAccess` - string
+
+Disables the use of the global `sinon` object. This ensures the use of a sandboxed version of `sinon` when in tests. 
 
 ### Accessing Sinon from Within Tests
 

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -2,27 +2,28 @@ import QUnit from 'qunit';
 import { warn } from '@ember/debug';
 
 const SINON = self.sinon;
+const REQUIRED_SANDBOX_APIS = ['clock'];
+
+let errorOnGlobalSinonAccess;
+let currentSandbox;
+
+export function setOptions(options = {}) {
+  errorOnGlobalSinonAccess = !!options.errorOnGlobalSinonAccess;
+}
 
 export function createSandbox() {
-  const sandbox = SINON.sandbox.create();
-  QUnit.config.current.testEnvironment.sandbox = self.sinon = sandbox;
+  currentSandbox = SINON.sandbox.create();
 
-  sandbox.sandbox = {
-    create() {
-      warn(
-        'Explicitly calling `sinon.sandbox.create()` in conjunction with ember-sinon-sandbox is not recommended. Please use `this.sandbox` available in your tests to access sinon.',
-        true,
-        {
-          id: 'ember-sinon-sandbox'
-        }
-      );
-
-      return sandbox;
-    }
+  if (errorOnGlobalSinonAccess) {
+    disableSinonGlobal();
+  } else {
+    disableSinonGlobalAPIs(currentSandbox);
   }
 
-  sandbox.__restore = sandbox.restore;
-  sandbox.restore = function() {
+  QUnit.config.current.testEnvironment.sandbox = currentSandbox;
+
+  currentSandbox.__restore = currentSandbox.restore;
+  currentSandbox.restore = function() {
     warn(
       'Explicitly calling `sinon.sandbox.restore()` in conjunction with ember-sinon-sandbox does not restore the sandbox. Sandboxes are automatically restored after each test.',
       true,
@@ -31,27 +32,62 @@ export function createSandbox() {
       }
     )
   };
-
-  sandbox.assert = {};
-  Object.keys(SINON.assert).forEach(assertMethod => {
-    sandbox.assert[assertMethod] = function() {
-      throw new Error('The `sinon.assert` API is not available in conjunction with ember-sinon-sandbox. Please use your test framework\'s assert API.');
-    }
-  });
-
-  sandbox.fakeServer = {
-    create() {
-      throw new Error('The `sinon.fakeServer` API is not available in conjunction with ember-sinon-sandbox.');
-    }
-  }
 }
 
 export function restoreSandbox() {
-  self.sinon.__restore();
-  self.sinon = null;
+  currentSandbox.__restore();
+
+  QUnit.config.current.testEnvironment.sandbox = currentSandbox = null;
+
+  if (!errorOnGlobalSinonAccess) {
+    self.sinon = null;
+  }
 }
 
-export default function setupSinonSandbox(testEnvironment = QUnit) {
+function disableSinonGlobal() {
+  Object.defineProperty(self, 'sinon', {
+    get() {
+      throw new Error('Sinon is not available globally because it has been disabled by setting `disableGlobalSinon` to `true` when setting up ember-sinon-sandbox.')
+    }
+  });
+}
+
+function disableSinonGlobalAPIs(sandbox) {
+  for (let key in SINON) {
+    if (!sandbox[key] && !REQUIRED_SANDBOX_APIS.includes(key)) {
+      if (key === 'sandbox') {
+        sandbox.sandbox = {
+          create() {
+            warn(
+              'Explicitly calling `sinon.sandbox.create()` in conjunction with ember-sinon-sandbox is not recommended. Please use `this.sandbox` available in your tests to access sinon.',
+              true,
+              {
+                id: 'ember-sinon-sandbox'
+              }
+            );
+
+            return sandbox;
+          }
+        }
+      }
+      else {
+        Object.defineProperty(sandbox, key, {
+          get() {
+            throw new Error(`The sinon.${key} API is not available in conjunction with ember-sinon-sandbox.`);
+          }
+        })
+      }
+    }
+  }
+
+  self.sinon = sandbox;
+
+  return sandbox;
+}
+
+export default function setupSinonSandbox(testEnvironment = QUnit, options = {}) {
+  setOptions(options);
+
   testEnvironment.testStart(createSandbox);
   testEnvironment.testDone(restoreSandbox);
 }

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -43,7 +43,7 @@ export function restoreSandbox() {
 function disableSinonGlobal() {
   Object.defineProperty(self, 'sinon', {
     get() {
-      throw new Error('Sinon is not available globally because it has been disabled by setting `disableGlobalSinon` to `true` when setting up ember-sinon-sandbox.')
+      throw new Error('Sinon is not available globally because it has been disabled by setting `disableGlobalSinon` to `true` when setting up ember-sinon-sandbox. https://git.io/v56JW')
     }
   });
 }

--- a/tests/unit/sinon-sandbox-no-global-access-test.js
+++ b/tests/unit/sinon-sandbox-no-global-access-test.js
@@ -1,0 +1,112 @@
+import { module, test } from 'qunit';
+import setupSinonSandbox, { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
+
+module('Unit | ember-sinon-sandbox | No global access', {
+  beforeEach() {
+    setOptions({ errorOnGlobalSinonAccess: true });
+  },
+
+  afterEach() {
+    setOptions({ errorOnGlobalSinonAccess: false });
+  }
+});
+
+test('errors when accessing the sinon global', function(assert) {
+  assert.expect(1);
+
+  createSandbox();
+
+  assert.throws(() => {
+    let sinon = self.sinon;
+    sinon.spy();
+  }, 'self.sinon is not available');
+
+  restoreSandbox();
+});
+
+test('calling `sinon.sandbox.restore()` noops to ensure restoration is controlled', function(assert) {
+  assert.expect(2);
+
+  createSandbox();
+
+  this.sandbox.spy();
+
+  assert.equal(this.sandbox.fakes.length, 1);
+
+  this.sandbox.restore();
+
+  assert.equal(this.sandbox.fakes.length, 1);
+
+  restoreSandbox();
+});
+
+test('using sinon.assert.* methods throw an error when `errorOnGlobalSinonAccess`', function(assert) {
+  assert.expect(1);
+
+  setOptions({ errorOnGlobalSinonAccess: true });
+  createSandbox();
+
+  assert.throws(() => {
+    this.sandbox.assert.calledOnce()
+  }, 'sinon.assert methods throw an error');
+
+  restoreSandbox();
+});
+
+test('using sinon.fakeServer.create throws an error', function(assert) {
+  assert.expect(1);
+
+  createSandbox();
+
+  assert.throws(() => {
+    this.sandbox.fakeServer.create()
+  }, 'sandbox.fakeServer.create throws and error');
+
+  restoreSandbox();
+});
+
+test('ensures sandbox is restored correctly', function(assert) {
+  assert.expect(1);
+
+  createSandbox();
+  restoreSandbox();
+
+  assert.notOk(this.sandbox, 'Sandbox is restored');
+});
+
+test('ensures sandbox instances are different for each test', function(assert) {
+  assert.expect(10);
+
+  let previousSandbox;
+
+  for (let i = 0; i < 10; i++) {
+    createSandbox();
+    assert.notEqual(previousSandbox, this.sandbox, 'Sandbox instance is unique per test');
+    previousSandbox = Object.assign({}, this.sandbox);
+    restoreSandbox();
+  }
+});
+
+test('configuring setup/restore', function(assert) {
+  assert.expect(4);
+
+  let testStartCalled = false;
+  let testDoneCalled = false;
+
+  let testEnvironment = {
+    testStart(callback) {
+      testStartCalled = true;
+      assert.equal(callback, createSandbox);
+    },
+
+    testDone(callback) {
+      testDoneCalled = true;
+      assert.equal(callback, restoreSandbox);
+    }
+  };
+
+  setupSinonSandbox(testEnvironment, { errorOnGlobalSinonAccess: true });
+
+  assert.ok(testStartCalled, 'testEnvironment.testStart is called');
+  assert.ok(testDoneCalled, 'testEnvironment.testDone is called');
+});

--- a/tests/unit/sinon-sandbox-no-global-access-test.js
+++ b/tests/unit/sinon-sandbox-no-global-access-test.js
@@ -1,18 +1,19 @@
+/* global sinon */
 import { module, test } from 'qunit';
 import setupSinonSandbox, { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
 
 module('Unit | ember-sinon-sandbox | No global access', {
-  beforeEach() {
+  before() {
     setOptions({ errorOnGlobalSinonAccess: true });
   },
 
-  afterEach() {
+  after() {
     setOptions({ errorOnGlobalSinonAccess: false });
   }
 });
 
 test('errors when accessing the sinon global', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   createSandbox();
 
@@ -20,6 +21,10 @@ test('errors when accessing the sinon global', function(assert) {
     let sinon = self.sinon;
     sinon.spy();
   }, 'self.sinon is not available');
+
+  assert.throws(() => {
+    sinon.spy();
+  }, 'sinon is not available');
 
   restoreSandbox();
 });
@@ -93,19 +98,22 @@ test('configuring setup/restore', function(assert) {
   let testStartCalled = false;
   let testDoneCalled = false;
 
-  let testEnvironment = {
-    testStart(callback) {
-      testStartCalled = true;
-      assert.equal(callback, createSandbox);
-    },
+  let options = {
+    QUnit: {
+      testStart(callback) {
+        testStartCalled = true;
+        assert.equal(callback, createSandbox);
+      },
 
-    testDone(callback) {
-      testDoneCalled = true;
-      assert.equal(callback, restoreSandbox);
-    }
+      testDone(callback) {
+        testDoneCalled = true;
+        assert.equal(callback, restoreSandbox);
+      }
+    },
+    errorOnGlobalSinonAccess: true
   };
 
-  setupSinonSandbox(testEnvironment, { errorOnGlobalSinonAccess: true });
+  setupSinonSandbox(options);
 
   assert.ok(testStartCalled, 'testEnvironment.testStart is called');
   assert.ok(testDoneCalled, 'testEnvironment.testDone is called');

--- a/tests/unit/sinon-sandbox-with-global-access-test.js
+++ b/tests/unit/sinon-sandbox-with-global-access-test.js
@@ -1,7 +1,15 @@
 import QUnit, { module, test } from 'qunit';
-import setupSinonSandbox, { createSandbox, restoreSandbox } from 'ember-sinon-sandbox/test-support';
+import setupSinonSandbox, { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
 
-module('Unit | ember-sinon-sandbox | With global access');
+module('Unit | ember-sinon-sandbox | With global access', {
+  before() {
+    setOptions({ errorOnGlobalSinonAccess: false });
+  },
+
+  after() {
+    setOptions({ errorOnGlobalSinonAccess: true });
+  }
+});
 
 test('stores sandbox created as module property', function(assert) {
   assert.expect(3);
@@ -98,19 +106,23 @@ test('configuring setup/restore', function(assert) {
   let testStartCalled = false;
   let testDoneCalled = false;
 
-  let testEnvironment = {
-    testStart(callback) {
-      testStartCalled = true;
-      assert.equal(callback, createSandbox);
-    },
 
-    testDone(callback) {
-      testDoneCalled = true;
-      assert.equal(callback, restoreSandbox);
-    }
+  let options = {
+    QUnit: {
+      testStart(callback) {
+        testStartCalled = true;
+        assert.equal(callback, createSandbox);
+      },
+
+      testDone(callback) {
+        testDoneCalled = true;
+        assert.equal(callback, restoreSandbox);
+      }
+    },
+    errorOnGlobalSinonAccess: false
   };
 
-  setupSinonSandbox(testEnvironment);
+  setupSinonSandbox(options);
 
   assert.ok(testStartCalled, 'testEnvironment.testStart is called');
   assert.ok(testDoneCalled, 'testEnvironment.testDone is called');

--- a/tests/unit/sinon-sandbox-with-global-access-test.js
+++ b/tests/unit/sinon-sandbox-with-global-access-test.js
@@ -1,7 +1,7 @@
 import QUnit, { module, test } from 'qunit';
 import setupSinonSandbox, { createSandbox, restoreSandbox } from 'ember-sinon-sandbox/test-support';
 
-module('Unit | ember-sinon-sandbox');
+module('Unit | ember-sinon-sandbox | With global access');
 
 test('stores sandbox created as module property', function(assert) {
   assert.expect(3);


### PR DESCRIPTION
Adds the ability to configure disabling `self.sinon` by passing options to the `setupSinonSandbox` function.

Also disables all `sinon` global methods when accessing them via a sandbox.