### PR TITLE
Fixing logic associated with required APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -50,7 +50,7 @@ function disableSinonGlobal() {
 
 function disableSinonGlobalAPIs(sandbox) {
   for (let key in SINON) {
-    if (!sandbox[key] && !REQUIRED_SANDBOX_APIS.indexOf(key) > -1) {
+    if (!sandbox[key] && REQUIRED_SANDBOX_APIS.indexOf(key) === -1) {
       if (key === 'sandbox') {
         sandbox.sandbox = {
           create() {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -18,6 +18,19 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.12',
+      bower: {
+        dependencies: {
+          'ember': '~2.12.2'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -18,14 +18,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-lts-2.12',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
-    },
-    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/tests/unit/sinon-sandbox-no-global-access-test.js
+++ b/tests/unit/sinon-sandbox-no-global-access-test.js
@@ -45,6 +45,18 @@ test('calling `sinon.sandbox.restore()` noops to ensure restoration is controlle
   restoreSandbox();
 });
 
+test('using useFakeTimers API continues to work', function(assert) {
+  assert.expect(1);
+
+  createSandbox();
+
+  let clock = this.sandbox.useFakeTimers();
+
+  assert.ok(clock, 'The clock API continues to work after forced sandboxing.');
+
+  restoreSandbox();
+});
+
 test('using sinon.assert.* methods throw an error when `errorOnGlobalSinonAccess`', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/sinon-sandbox-with-global-access-test.js
+++ b/tests/unit/sinon-sandbox-with-global-access-test.js
@@ -54,6 +54,18 @@ test('calling `sinon.sandbox.restore()` noops to ensure restoration is controlle
   restoreSandbox();
 });
 
+test('using useFakeTimers API continues to work', function(assert) {
+  assert.expect(1);
+
+  createSandbox();
+
+  let clock = this.sandbox.useFakeTimers();
+
+  assert.ok(clock, 'The clock API continues to work after forced sandboxing.');
+
+  restoreSandbox();
+});
+
 test('using sinon.assert.* methods throws an error', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Fixes a bug associated with enabling required APIs, specifically the `clock` API that's used in conjunction with `useFakeTimers`