### PR TITLE
Changing invocation to be in beforeEach/afterEach rather than testDone

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -10,8 +10,16 @@ export function setOptions(options = {}) {
   errorOnGlobalSinonAccess = !!options.errorOnGlobalSinonAccess;
 }
 
+export function setup() {
+  let currentTest = QUnit.config.current;
+
+  currentTest.module.hooks.beforeEach.push(createSandbox);
+  currentTest.module.hooks.afterEach.push(restoreSandbox);
+}
+
 export function createSandbox() {
-  let sandbox = QUnit.config.current.testEnvironment.sandbox = SINON.sandbox.create();
+  let currentTest = QUnit.config.current;
+  let sandbox = currentTest.testEnvironment.sandbox = SINON.sandbox.create();
 
   if (errorOnGlobalSinonAccess) {
     disableSinonGlobal();
@@ -86,6 +94,5 @@ export default function setupSinonSandbox(options = {}) {
 
   let testEnvironment = options.QUnit || self.QUnit;
 
-  testEnvironment.testStart(createSandbox);
-  testEnvironment.testDone(restoreSandbox);
+  testEnvironment.testStart(setup);
 }

--- a/testem.js
+++ b/testem.js
@@ -9,11 +9,14 @@ module.exports = {
     'Chrome'
   ],
   'browser_args': {
-      'Chrome': [
+    Chrome: {
+      mode: 'ci',
+      args: [
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=9222',
         '--window-size=1440,900'
-      ],
+      ]
+    },
   }
 };

--- a/tests/unit/sinon-sandbox-no-global-access-test.js
+++ b/tests/unit/sinon-sandbox-no-global-access-test.js
@@ -1,6 +1,6 @@
-/* global sinon */
+/* global: sinon */
 import { module, test } from 'qunit';
-import setupSinonSandbox, { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
+import { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
 
 module('Unit | ember-sinon-sandbox | No global access', {
   before() {
@@ -23,83 +23,9 @@ test('errors when accessing the sinon global', function(assert) {
   }, 'self.sinon is not available');
 
   assert.throws(() => {
+    let sinon = self.sinon;
     sinon.spy();
   }, 'sinon is not available');
-
-  restoreSandbox();
-});
-
-test('calling `sinon.sandbox.restore()` noops to ensure restoration is controlled', function(assert) {
-  assert.expect(2);
-
-  createSandbox();
-
-  this.sandbox.spy();
-
-  assert.equal(this.sandbox.fakes.length, 1);
-
-  this.sandbox.restore();
-
-  assert.equal(this.sandbox.fakes.length, 1);
-
-  restoreSandbox();
-});
-
-test('using useFakeTimers API continues to work', function(assert) {
-  assert.expect(1);
-
-  createSandbox();
-
-  let clock = this.sandbox.useFakeTimers();
-
-  assert.ok(clock, 'The clock API continues to work after forced sandboxing.');
-
-  restoreSandbox();
-});
-
-test('using useFakeXMLHttpRequest API continues to work', function(assert) {
-  assert.expect(1);
-
-  let requests = [];
-
-  createSandbox();
-
-  let fakeXHR = this.sandbox.useFakeXMLHttpRequest();
-  fakeXHR.onCreate = (req) => {
-    requests.push(req);
-  };
-
-  let xhr = new XMLHttpRequest();
-  xhr.addEventListener("load", () => {});
-  xhr.open("GET", "http://www.example.org/example.txt");
-  xhr.send();
-
-  assert.equal(requests.length, 1, 'The fake XHR API continues to work after forced sandboxing.');
-
-  restoreSandbox();
-});
-
-test('using sinon.assert.* methods throw an error when `errorOnGlobalSinonAccess`', function(assert) {
-  assert.expect(1);
-
-  setOptions({ errorOnGlobalSinonAccess: true });
-  createSandbox();
-
-  assert.throws(() => {
-    this.sandbox.assert.calledOnce()
-  }, 'sinon.assert methods throw an error');
-
-  restoreSandbox();
-});
-
-test('using sinon.fakeServer.create throws an error', function(assert) {
-  assert.expect(1);
-
-  createSandbox();
-
-  assert.throws(() => {
-    this.sandbox.fakeServer.create()
-  }, 'sandbox.fakeServer.create throws and error');
 
   restoreSandbox();
 });
@@ -124,31 +50,4 @@ test('ensures sandbox instances are different for each test', function(assert) {
     previousSandbox = Object.assign({}, this.sandbox);
     restoreSandbox();
   }
-});
-
-test('configuring setup/restore', function(assert) {
-  assert.expect(4);
-
-  let testStartCalled = false;
-  let testDoneCalled = false;
-
-  let options = {
-    QUnit: {
-      testStart(callback) {
-        testStartCalled = true;
-        assert.equal(callback, createSandbox);
-      },
-
-      testDone(callback) {
-        testDoneCalled = true;
-        assert.equal(callback, restoreSandbox);
-      }
-    },
-    errorOnGlobalSinonAccess: true
-  };
-
-  setupSinonSandbox(options);
-
-  assert.ok(testStartCalled, 'testEnvironment.testStart is called');
-  assert.ok(testDoneCalled, 'testEnvironment.testDone is called');
 });

--- a/tests/unit/sinon-sandbox-test.js
+++ b/tests/unit/sinon-sandbox-test.js
@@ -1,0 +1,151 @@
+import QUnit, { module, test } from 'qunit';
+import setupSinonSandbox, { setup, createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
+
+[
+  true,
+  false
+].forEach(errorOnGlobalSinonAccess => {
+  module(`Unit | ember-sinon-sandbox | errorOnGlobalSinonAccess is ${errorOnGlobalSinonAccess}`, {
+    before() {
+      setOptions({
+        errorOnGlobalSinonAccess
+      });
+    },
+
+    after() {
+      setOptions({
+        errorOnGlobalSinonAccess: !errorOnGlobalSinonAccess
+      });
+    }
+  });
+
+  test('stores sandbox created as module property', function(assert) {
+    assert.expect(2);
+
+    assert.notOk(QUnit.config.current.testEnvironment.sandbox);
+
+    createSandbox();
+
+    const sandbox =  QUnit.config.current.testEnvironment.sandbox;
+
+    assert.ok(sandbox, 'Sandbox is defined in testEnvironment');
+
+    restoreSandbox();
+  });
+
+  test('calling `sinon.sandbox.restore()` noops to ensure restoration is controlled', function(assert) {
+    assert.expect(2);
+
+    createSandbox();
+
+    this.sandbox.spy();
+
+    assert.equal(this.sandbox.fakes.length, 1);
+
+    this.sandbox.restore();
+
+    assert.equal(this.sandbox.fakes.length, 1);
+
+    restoreSandbox();
+  });
+
+  test('using useFakeTimers API continues to work', function(assert) {
+    assert.expect(1);
+
+    createSandbox();
+
+    let clock = this.sandbox.useFakeTimers();
+
+    assert.ok(clock, 'The clock API continues to work after forced sandboxing.');
+
+    restoreSandbox();
+  });
+
+  test('using useFakeXMLHttpRequest API continues to work', function(assert) {
+    assert.expect(1);
+
+    let requests = [];
+
+    createSandbox();
+
+    let fakeXHR = this.sandbox.useFakeXMLHttpRequest();
+    fakeXHR.onCreate = (req) => {
+      requests.push(req);
+    };
+
+    let xhr = new XMLHttpRequest();
+    xhr.addEventListener("load", () => {});
+    xhr.open("GET", "http://www.example.org/example.txt");
+    xhr.send();
+
+    assert.equal(requests.length, 1, 'The fake XHR API continues to work after forced sandboxing.');
+
+    restoreSandbox();
+  });
+
+  test('using sinon.assert.* methods throws an error', function(assert) {
+    assert.expect(1);
+
+    createSandbox();
+
+    assert.throws(() => {
+      this.sandbox.assert.calledOnce()
+    }, 'sinon.assert methods throw an error');
+
+    restoreSandbox();
+  });
+
+  test('using sinon.fakeServer.create throws an error', function(assert) {
+    assert.expect(1);
+
+    createSandbox();
+
+    assert.throws(() => {
+      this.sandbox.fakeServer.create()
+    }, 'sandbox.fakeServer.create throws and error');
+
+    restoreSandbox();
+  });
+
+  test('ensures sandbox is restored correctly', function(assert) {
+    assert.expect(1);
+
+    createSandbox();
+    restoreSandbox();
+
+    assert.notOk(this.sandbox, 'Sandbox is restored');
+  });
+
+  test('ensures sandbox instances are different for each test', function(assert) {
+    assert.expect(10);
+
+    let previousSandbox;
+
+    for (let i = 0; i < 10; i++) {
+      createSandbox();
+      assert.notEqual(previousSandbox, this.sandbox, 'Sandbox instance is unique per test');
+      previousSandbox = Object.assign({}, this.sandbox);
+      restoreSandbox();
+    }
+  });
+
+  test('configuring setup/restore', function(assert) {
+    assert.expect(2);
+
+    let testStartCalled = false;
+
+    let options = {
+      QUnit: {
+        testStart(callback) {
+          testStartCalled = true;
+          assert.equal(callback, setup);
+        }
+      },
+      errorOnGlobalSinonAccess
+    };
+
+    setupSinonSandbox(options);
+
+    assert.ok(testStartCalled, 'testEnvironment.testStart is called');
+  });
+});

--- a/tests/unit/sinon-sandbox-with-global-access-test.js
+++ b/tests/unit/sinon-sandbox-with-global-access-test.js
@@ -1,5 +1,6 @@
+/* global: sinon */
 import QUnit, { module, test } from 'qunit';
-import setupSinonSandbox, { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
+import { createSandbox, restoreSandbox, setOptions } from 'ember-sinon-sandbox/test-support';
 
 module('Unit | ember-sinon-sandbox | With global access', {
   before() {
@@ -11,7 +12,19 @@ module('Unit | ember-sinon-sandbox | With global access', {
   }
 });
 
-test('stores sandbox created as module property', function(assert) {
+test('does not error when accessing the sinon global', function(assert) {
+  assert.expect(2);
+
+  createSandbox();
+
+  assert.ok(self.sinon, 'self.sinon is available');
+
+  assert.ok(self.sinon.spy(), 'sinon spy is available');
+
+  restoreSandbox();
+});
+
+test('sandbox created as module property and global sinon are the same sandbox instance', function(assert) {
   assert.expect(3);
 
   assert.notOk(QUnit.config.current.testEnvironment.sandbox);
@@ -38,80 +51,6 @@ test('stubbing out sandbox.create returns the already created sandbox', function
   restoreSandbox();
 });
 
-test('calling `sinon.sandbox.restore()` noops to ensure restoration is controlled', function(assert) {
-  assert.expect(2);
-
-  createSandbox();
-
-  this.sandbox.spy();
-
-  assert.equal(this.sandbox.fakes.length, 1);
-
-  this.sandbox.restore();
-
-  assert.equal(this.sandbox.fakes.length, 1);
-
-  restoreSandbox();
-});
-
-test('using useFakeTimers API continues to work', function(assert) {
-  assert.expect(1);
-
-  createSandbox();
-
-  let clock = this.sandbox.useFakeTimers();
-
-  assert.ok(clock, 'The clock API continues to work after forced sandboxing.');
-
-  restoreSandbox();
-});
-
-test('using useFakeXMLHttpRequest API continues to work', function(assert) {
-  assert.expect(1);
-
-  let requests = [];
-
-  createSandbox();
-
-  let fakeXHR = this.sandbox.useFakeXMLHttpRequest();
-  fakeXHR.onCreate = (req) => {
-    requests.push(req);
-  };
-
-  let xhr = new XMLHttpRequest();
-  xhr.addEventListener("load", () => {});
-  xhr.open("GET", "http://www.example.org/example.txt");
-  xhr.send();
-
-  assert.equal(requests.length, 1, 'The fake XHR API continues to work after forced sandboxing.');
-
-  restoreSandbox();
-});
-
-test('using sinon.assert.* methods throws an error', function(assert) {
-  assert.expect(1);
-
-  createSandbox();
-
-  assert.throws(() => {
-    this.sandbox.assert.calledOnce()
-  }, 'sinon.assert methods throw an error');
-
-  restoreSandbox();
-});
-
-test('using sinon.fakeServer.create throws an error', function(assert) {
-  assert.expect(1);
-
-  createSandbox();
-
-  assert.throws(() => {
-    this.sandbox.fakeServer.create()
-  }, 'sandbox.fakeServer.create throws and error');
-
-  restoreSandbox();
-});
-
 test('ensures sandbox is restored correctly', function(assert) {
   assert.expect(1);
 
@@ -132,32 +71,4 @@ test('ensures sandbox instances are different for each test', function(assert) {
     previousSandbox = Object.assign({}, self.sinon);
     restoreSandbox();
   }
-});
-
-test('configuring setup/restore', function(assert) {
-  assert.expect(4);
-
-  let testStartCalled = false;
-  let testDoneCalled = false;
-
-
-  let options = {
-    QUnit: {
-      testStart(callback) {
-        testStartCalled = true;
-        assert.equal(callback, createSandbox);
-      },
-
-      testDone(callback) {
-        testDoneCalled = true;
-        assert.equal(callback, restoreSandbox);
-      }
-    },
-    errorOnGlobalSinonAccess: false
-  };
-
-  setupSinonSandbox(options);
-
-  assert.ok(testStartCalled, 'testEnvironment.testStart is called');
-  assert.ok(testDoneCalled, 'testEnvironment.testDone is called');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,12 +146,6 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
-amd-name-resolver@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz#d3e4ba2dfcaab1d820c1be9de947c67828cfe595"
-  dependencies:
-    ensure-posix-path "^1.0.1"
-
 amd-name-resolver@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz#814301adfe8a2f109f6e84d5e935196efb669615"
@@ -1682,6 +1676,10 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
+deep-freeze@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -1965,11 +1963,11 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli@~2.14.2:
-  version "2.14.2"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.14.2.tgz#f2c8c75d486ce6cc6b7ffbc22ebef8b32bb242b7"
+ember-cli@~2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.15.1.tgz#773add3cc18e5068f1c5f43a77544efa2712e47b"
   dependencies:
-    amd-name-resolver "0.0.6"
+    amd-name-resolver "0.0.7"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
     bower-config "^1.3.0"
     bower-endpoint-parser "0.2.2"
@@ -1994,9 +1992,9 @@ ember-cli@~2.14.2:
     console-ui "^1.0.2"
     core-object "^3.1.3"
     dag-map "^2.0.2"
+    deep-freeze "^0.0.1"
     diff "^3.2.0"
     ember-cli-broccoli-sane-watcher "^2.0.4"
-    ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-legacy-blueprints "^0.1.2"
     ember-cli-lodash-subset "^1.0.11"
@@ -2005,8 +2003,7 @@ ember-cli@~2.14.2:
     ember-cli-string-utils "^1.0.0"
     ember-try "^0.2.15"
     ensure-posix-path "^1.0.2"
-    escape-string-regexp "^1.0.3"
-    execa "^0.6.0"
+    execa "^0.7.0"
     exists-sync "0.0.4"
     exit "^0.1.2"
     express "^4.12.3"
@@ -2023,7 +2020,7 @@ ember-cli@~2.14.2:
     heimdalljs-logger "^0.1.7"
     http-proxy "^1.9.0"
     inflection "^1.7.0"
-    is-git-url "^0.2.0"
+    is-git-url "^1.0.0"
     isbinaryfile "^3.0.0"
     js-yaml "^3.6.1"
     json-stable-stringify "^1.0.1"
@@ -2047,7 +2044,7 @@ ember-cli@~2.14.2:
     sort-package-json "^1.4.0"
     symlink-or-copy "^1.1.8"
     temp "0.8.3"
-    testem "^1.15.0"
+    testem "^1.18.0"
     tiny-lr "^1.0.3"
     tree-sync "^1.2.1"
     uuid "^3.0.0"
@@ -2232,7 +2229,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2343,9 +2340,9 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
-execa@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -3120,10 +3117,6 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-git-url@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/is-git-url/-/is-git-url-0.2.3.tgz#445200d6fbd6da028fb5e01440d9afc93f3ccb64"
 
 is-git-url@^1.0.0:
   version "1.0.0"
@@ -4993,7 +4986,7 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-testem@^1.15.0:
+testem@^1.18.0:
   version "1.18.4"
   resolved "https://registry.yarnpkg.com/testem/-/testem-1.18.4.tgz#e45fed922bec2f54a616c43f11922598ac97eb41"
   dependencies:


### PR DESCRIPTION
This PR aims to address a timing issue when the following occurs:

1. A test uses `useFakeTimers` and returns a clock
1. The `clock` returned from `useFakeTimers` is not restored in the test
1. The `clock` returned from `useFakeTimers` is not restored in `afterEach` (due to sinon sandbox owning the restoration)
1. `Backburner.next` is used, resulting in it using the stubbed `setTimeout` from the test

This specifically happens due to the use of `testDone` to restore the sandbox. Moving the API to use `afterEach` addresses the issue.