### PR TITLE
Update Tests to Not Use Private APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: required
 dist: trusty

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,5 @@
 import resolver from './helpers/resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import { setResolver } from '@ember/test-helpers';
 import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);

--- a/tests/unit/sinon-sandbox-test.js
+++ b/tests/unit/sinon-sandbox-test.js
@@ -17,15 +17,18 @@ import {
     test('calling `sinon.sandbox.restore()` can be called explicitly and via `restoreSandbox`', function(assert) {
       assert.expect(2);
 
+      const foo = () => true;
+      const bar = { foo };
+
       createSandbox();
 
-      this.sandbox.spy();
+      this.sandbox.stub(bar, 'foo');
 
-      assert.equal(this.sandbox.fakes.length, 1);
+      assert.notEqual(bar.foo, foo);
 
       this.sandbox.restore();
 
-      assert.equal(this.sandbox.fakes.length, 0);
+      assert.equal(bar.foo, foo);
 
       restoreSandbox();
     });


### PR DESCRIPTION
This is a small PR that removes the need to reach into sinon's private API. We can accomplish the same task by creating a stub, and then ensuring that it gets restored after we call `this.sandbox.stub`